### PR TITLE
fix: adjust courses scroll-margin-top to match those of about

### DIFF
--- a/src/blocks/courses/courses.css
+++ b/src/blocks/courses/courses.css
@@ -1,5 +1,5 @@
 .courses {
-  scroll-margin-top: 79px;
+  scroll-margin-top: 120px;
   width: 100%;
   max-width: 1220px;
   margin: 0;


### PR DESCRIPTION
из-за того, что над курсами раньше ничего не было, свойство отличалось от соответсвующего в about