### PR TITLE
fix: change popup z-index to prevent header overlapping

### DIFF
--- a/src/blocks/popup/popup.css
+++ b/src/blocks/popup/popup.css
@@ -1,5 +1,6 @@
 .popup {
   position: fixed;
+  z-index: 100;
   top: 0;
   left: 0;
   display: flex;


### PR DESCRIPTION
попап на мобильной версии перекрывается хедером или картинкой about, т.к. у них з-индекс выставлен явно