### PR TITLE
Hotfix/courses

### DIFF
--- a/src/blocks/courses/__buttons/courses__buttons.css
+++ b/src/blocks/courses/__buttons/courses__buttons.css
@@ -4,7 +4,7 @@
   margin-top: auto;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__buttons {
     margin-top: 15px;
   }

--- a/src/blocks/courses/__card-text/courses__card-text.css
+++ b/src/blocks/courses/__card-text/courses__card-text.css
@@ -1,29 +1,23 @@
 .courses__card-text {
   min-height: min-content;
   max-height: 100%;
-  margin: 0 0 18px;
-  padding: 0;
+  margin: 0 0 14px;
   text-overflow: ellipsis;
-}
-
-.courses__skills .courses__card-text {
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.courses__card-text:last-child {
-  margin-bottom: 0;
 }
 
 @media screen and (max-width: 768px) and (min-width: 426px) {
   .courses__card-text {
     margin-bottom: 15px;
   }
+}
 
-  .courses__card-text + .courses__skills {
-    margin-top: 15px;
+@media screen and (max-width: 425px) {
+  .courses__card-text {
+    font-size: 16px;
+    line-height: 20px;
+  }
+
+  .courses__card-text:last-of-type {
+    margin-bottom: 18px;
   }
 }

--- a/src/blocks/courses/__card-title/courses__card-title.css
+++ b/src/blocks/courses/__card-title/courses__card-title.css
@@ -14,7 +14,6 @@
     margin-bottom: 30px;
     font-size: 30px;
     line-height: 37px;
-    letter-spacing: -.5px;
   }
 }
 
@@ -23,5 +22,6 @@
     margin-bottom: 20px;
     font-size: 24px;
     line-height: 29px;
+    letter-spacing: -.5px;
   }
 }

--- a/src/blocks/courses/__card/_size/courses__card_size_big.css
+++ b/src/blocks/courses/__card/_size/courses__card_size_big.css
@@ -11,3 +11,8 @@
   }
 }
 
+@media screen and (max-width: 425px) {
+  .courses__card_size_big {
+    min-width: unset;
+  }
+}

--- a/src/blocks/courses/__card/_size/courses__card_size_small.css
+++ b/src/blocks/courses/__card/_size/courses__card_size_small.css
@@ -21,3 +21,15 @@
     max-width: 594px;
   }
 }
+
+@media screen and (max-width: 425px) {
+  .courses__card_size_small {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .courses__card_size_small:nth-child(3n+2) {
+    width: 100%;
+    min-width: unset;
+  }
+}

--- a/src/blocks/courses/__card/_size/courses__card_size_small.css
+++ b/src/blocks/courses/__card/_size/courses__card_size_small.css
@@ -8,7 +8,7 @@
   width: calc((100% + 20px) / 3);
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__card_size_small {
     width: calc(100% - 20px);
     min-width: 300px;

--- a/src/blocks/courses/__code-list/courses__code-list.css
+++ b/src/blocks/courses/__code-list/courses__code-list.css
@@ -14,3 +14,9 @@
     justify-items: center;
   }
 }
+
+@media screen and (max-width: 425px) {
+  .courses__code-list {
+    width: 100%;
+  }
+}

--- a/src/blocks/courses/__code-text/courses__code-text.css
+++ b/src/blocks/courses/__code-text/courses__code-text.css
@@ -14,5 +14,7 @@
 @media screen and (max-width: 425px) {
   .courses__code-text {
     margin-bottom: 10px;
+    font-size: 16px;
+    line-height: 20px;
   }
 }

--- a/src/blocks/courses/__code-title/courses__code-title.css
+++ b/src/blocks/courses/__code-title/courses__code-title.css
@@ -9,7 +9,7 @@
   font-feature-settings: 'pnum' on, 'lnum' on;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__code-title {
     margin: 40px auto 15px;
     font-size: 30px;

--- a/src/blocks/courses/__code/courses__code.css
+++ b/src/blocks/courses/__code/courses__code.css
@@ -17,7 +17,6 @@
 
 @media screen and (max-width: 425px) {
   .courses__code {
-    max-width: 654px;
     padding: 0 10px 10px;
     border-radius: 40px;
   }

--- a/src/blocks/courses/__code/courses__code.css
+++ b/src/blocks/courses/__code/courses__code.css
@@ -7,7 +7,7 @@
   border-radius: 70px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__code {
     max-width: 654px;
     padding-bottom: 30px;

--- a/src/blocks/courses/__includes-title/courses__includes-title.css
+++ b/src/blocks/courses/__includes-title/courses__includes-title.css
@@ -3,7 +3,7 @@
   letter-spacing: -.5px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__includes-title {
     margin-bottom: 15px;
     font-size: 18px;

--- a/src/blocks/courses/__includes/courses__includes.css
+++ b/src/blocks/courses/__includes/courses__includes.css
@@ -3,7 +3,7 @@
   margin: 48px 0 48px 29px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__includes {
     margin: 0;
   }

--- a/src/blocks/courses/__not-includes/courses__not-includes.css
+++ b/src/blocks/courses/__not-includes/courses__not-includes.css
@@ -4,7 +4,7 @@
   padding: 0 50px 0 0;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__not-includes {
     margin: 0;
     padding: 0;

--- a/src/blocks/courses/__not-includes/courses__not-includes.css
+++ b/src/blocks/courses/__not-includes/courses__not-includes.css
@@ -7,5 +7,6 @@
 @media screen and (max-width: 767px) {
   .courses__not-includes {
     margin: 0;
+    padding: 0;
   }
 }

--- a/src/blocks/courses/__price-pay/courses__price-pay.css
+++ b/src/blocks/courses/__price-pay/courses__price-pay.css
@@ -4,7 +4,7 @@
   margin: 0 0 30px 30px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 768px) {
   .courses__price-pay {
     margin: 0;
   }

--- a/src/blocks/courses/__skills-item/_unclamped/courses__skills-item_unclamped.css
+++ b/src/blocks/courses/__skills-item/_unclamped/courses__skills-item_unclamped.css
@@ -1,0 +1,3 @@
+.courses__skills-item_unclamped {
+  -webkit-line-clamp: unset;
+}

--- a/src/blocks/courses/__skills-item/courses__skills-item.css
+++ b/src/blocks/courses/__skills-item/courses__skills-item.css
@@ -1,29 +1,26 @@
 .courses__skills-item {
-  position: relative;
-  flex-basis: 100%;
-  padding: 0 0 25px 32px;
-  font-size: 18px;
-  line-height: 22px;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0 0 13px;
 }
 
-.courses__skills-item:last-of-type {
-  padding-bottom: 0;
+.courses__skills-item:last-child {
+  margin-bottom: 0;
 }
 
-.courses__skills-item::before {
-  position: absolute;
-  top: -3px;
-  left: -3px;
-  display: inline-block;
-  width: 30px;
-  height: 30px;
-  background-image: url('../../../images/icons/check_mark.svg');
-  background-repeat: no-repeat;
-  content: '';
-}
-
-@media screen and (min-width: 768px) {
+@media screen and (max-width: 768px) {
   .courses__skills-item {
-    flex-basis: calc(48% - 34px);
+    margin-bottom: 28px;
+  }
+}
+
+@media screen and (max-width: 425px) {
+  .courses__skills-item {
+    font-size: 16px;
+    line-height: 20px;
+    margin-bottom: 18px;
   }
 }

--- a/src/blocks/courses/__skills-item/courses__skills-item.css
+++ b/src/blocks/courses/__skills-item/courses__skills-item.css
@@ -1,10 +1,10 @@
 .courses__skills-item {
   display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
+  margin: 0 0 13px;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin: 0 0 13px;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
 }
 
 .courses__skills-item:last-child {
@@ -19,8 +19,8 @@
 
 @media screen and (max-width: 425px) {
   .courses__skills-item {
+    margin-bottom: 18px;
     font-size: 16px;
     line-height: 20px;
-    margin-bottom: 18px;
   }
 }

--- a/src/blocks/courses/__skills-list/courses__skills-list.css
+++ b/src/blocks/courses/__skills-list/courses__skills-list.css
@@ -4,6 +4,12 @@
   column-count: 1;
 }
 
+@media screen and (min-width: 425px) {
+  .courses__skills-list {
+    padding-top: 13px;
+  }
+}
+
 @media screen and (min-width: 768px) {
   .courses__skills-list {
     padding-top: 15px;

--- a/src/blocks/courses/__skills/courses__skills.css
+++ b/src/blocks/courses/__skills/courses__skills.css
@@ -1,16 +1,23 @@
 .courses__skills {
   margin: 0 0 30px;
   padding: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @media screen and (max-width: 768px) {
   .courses__skills {
-    margin-bottom: 13px;
+    padding-top: 14px;
+    margin-bottom: 14px;
   }
 }
 
 @media screen and (max-width: 425px) {
   .courses__skills {
+    padding-top: 0;
     margin-bottom: 20px;
   }
 }

--- a/src/blocks/courses/__skills/courses__skills.css
+++ b/src/blocks/courses/__skills/courses__skills.css
@@ -1,23 +1,23 @@
 .courses__skills {
+  display: -webkit-box;
   margin: 0 0 30px;
   padding: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
 }
 
 @media screen and (max-width: 768px) {
   .courses__skills {
-    padding-top: 14px;
     margin-bottom: 14px;
+    padding-top: 14px;
   }
 }
 
 @media screen and (max-width: 425px) {
   .courses__skills {
-    padding-top: 0;
     margin-bottom: 20px;
+    padding-top: 0;
   }
 }

--- a/src/blocks/courses/__spec-list/courses__spec-list.css
+++ b/src/blocks/courses/__spec-list/courses__spec-list.css
@@ -1,5 +1,11 @@
 .courses__spec-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0;
+}
+
+@media screen and (max-width: 425px) {
+  .courses__spec-list {
+    gap: 2px;
+  }
 }

--- a/src/blocks/courses/__spec-text/courses__spec-text.css
+++ b/src/blocks/courses/__spec-text/courses__spec-text.css
@@ -1,17 +1,17 @@
 .courses__spec-text {
   color: #2b2b2b;
   font-weight: 600;
-  letter-spacing: -.5px;
   font-size: 18px;
   line-height: 22px;
+  letter-spacing: -.5px;
   font-feature-settings: 'pnum' on, 'lnum' on;
 }
 
 @media screen and (max-width: 425px) {
   .courses__spec-text {
-    letter-spacing: unset;
     font-size: 16px;
     line-height: 20px;
+    letter-spacing: unset;
   }
 }
 

--- a/src/blocks/courses/__spec-text/courses__spec-text.css
+++ b/src/blocks/courses/__spec-text/courses__spec-text.css
@@ -1,13 +1,17 @@
 .courses__spec-text {
-  margin: 0;
-  padding: 0;
   color: #2b2b2b;
   font-weight: 600;
   letter-spacing: -.5px;
+  font-size: 18px;
+  line-height: 22px;
+  font-feature-settings: 'pnum' on, 'lnum' on;
 }
 
 @media screen and (max-width: 425px) {
   .courses__spec-text {
     letter-spacing: unset;
+    font-size: 16px;
+    line-height: 20px;
   }
 }
+

--- a/src/blocks/courses/__tags/courses__tags.css
+++ b/src/blocks/courses/__tags/courses__tags.css
@@ -8,6 +8,6 @@
 
 @media screen and (max-width: 425px) {
   .courses__tags {
-    margin: 20px 0;
+    margin: 21px 0;
   }
 }

--- a/src/blocks/courses/courses.css
+++ b/src/blocks/courses/courses.css
@@ -2,12 +2,12 @@
   scroll-margin-top: 120px;
   width: 100%;
   max-width: 1220px;
-  margin: 0;
   padding: 0;
 }
 
 @media screen and (max-width: 425px) {
   .courses {
     scroll-margin-top: 72px;
+    margin-bottom: 10px;
   }
 }

--- a/src/blocks/header/__burger/header__burger.css
+++ b/src/blocks/header/__burger/header__burger.css
@@ -5,14 +5,14 @@
   width: 28px;
   height: 29px;
   margin: 0 77px 0 0;
-  border: none;
   background-color: transparent;
+  border: none;
   outline: none;
 }
 
 .header__burger:hover {
-  opacity: .6;
   cursor: pointer;
+  opacity: .6;
 }
 
 .header__burger::before {

--- a/src/blocks/header/__mobile-logo/header__mobile-logo.css
+++ b/src/blocks/header/__mobile-logo/header__mobile-logo.css
@@ -10,8 +10,8 @@
 }
 
 .header__mobile-logo:hover {
-  opacity: .6;
   cursor: pointer;
+  opacity: .6;
 }
 
 @media screen and (max-width: 1110px) {

--- a/src/blocks/info/__paragraph/info__paragraph.css
+++ b/src/blocks/info/__paragraph/info__paragraph.css
@@ -21,7 +21,6 @@
 
 @media screen and (max-width: 425px) {
   .info__paragraph {
-    min-width: 290px;
     margin-right: 15px;
     margin-left: 15px;
     font-size: 24px;

--- a/src/blocks/info/info.css
+++ b/src/blocks/info/info.css
@@ -1,5 +1,4 @@
 .info {
   max-width: 1440px;
-  margin: 0;
   padding: 0;
 }

--- a/src/blocks/logo/logo.css
+++ b/src/blocks/logo/logo.css
@@ -4,8 +4,8 @@
 }
 
 .logo:hover {
-  opacity: .6;
   cursor: pointer;
+  opacity: .6;
 }
 
 @media screen and (max-width: 1280px) {

--- a/src/blocks/page/page.css
+++ b/src/blocks/page/page.css
@@ -13,3 +13,11 @@
     background: linear-gradient(180deg, #ffffff calc(100vw / (248 / 351) + 80px), #eaf0ff 0);
   }
 }
+
+li {
+  background-color: blue;
+}
+
+li > p {
+  background-color: red;
+}

--- a/src/blocks/page/page.css
+++ b/src/blocks/page/page.css
@@ -13,11 +13,3 @@
     background: linear-gradient(180deg, #ffffff calc(100vw / (248 / 351) + 80px), #eaf0ff 0);
   }
 }
-
-li {
-  background-color: blue;
-}
-
-li > p {
-  background-color: red;
-}

--- a/src/blocks/popup/__buttons/_type/popup__buttons_type_course.css
+++ b/src/blocks/popup/__buttons/_type/popup__buttons_type_course.css
@@ -1,6 +1,11 @@
-@media screen and (min-width: 768px) {
-  .popup__buttons_type_partner {
-    justify-content: center;
-    padding-top: 40px;
+.popup__buttons_type_course {
+  justify-content: flex-start;
+  padding-top: 30px;
+}
+
+@media screen and (max-width: 490px) {
+  .popup__buttons_type_course {
+    flex-direction: column-reverse;
+    padding-top: 20px;
   }
 }

--- a/src/blocks/popup/__buttons/_type/popup__buttons_type_partner.css
+++ b/src/blocks/popup/__buttons/_type/popup__buttons_type_partner.css
@@ -1,3 +1,6 @@
-.popup__buttons_type_course {
-  justify-content: flex-start;
+@media screen and (min-width: 768px) {
+  .popup__buttons_type_partner {
+    justify-content: center;
+    padding-top: 40px;
+  }
 }

--- a/src/blocks/popup/__close/_type/popup__close_type_button.css
+++ b/src/blocks/popup/__close/_type/popup__close_type_button.css
@@ -1,4 +1,12 @@
 .popup__close_type_button {
   padding: 0;
   font-size: 20px;
+  line-height: 24px;
+}
+
+@media screen and (max-width: 425px) {
+  .popup__close_type_button {
+    font-size: 16px;
+    line-height: 20px;
+  }
 }

--- a/src/blocks/popup/__container/_size/popup__container_size_small.css
+++ b/src/blocks/popup/__container/_size/popup__container_size_small.css
@@ -1,5 +1,5 @@
 .popup__container_size_small {
-  width: calc(100% - 5px * 2);
+  width: calc(100% - 15px * 2);
   max-width: 404px;
   padding: 30px 15px;
 }

--- a/src/blocks/popup/__container/popup__container.css
+++ b/src/blocks/popup/__container/popup__container.css
@@ -12,12 +12,14 @@
   .popup__container {
     width: calc(100% - 150px);
     padding: 30px;
+    border-radius: 50px;
   }
 }
 
 @media screen and (min-width: 768px) {
   .popup__container {
     padding: 30px;
+    border-radius: 60px;
   }
 }
 

--- a/src/blocks/popup/__title/popup__title.css
+++ b/src/blocks/popup/__title/popup__title.css
@@ -10,10 +10,10 @@
 
 @media screen and (min-width: 425px) {
   .popup__title {
+    padding-bottom: 30px;
     font-size: 30px;
     line-height: 37px;
     letter-spacing: -1px;
-    padding-bottom: 30px;
   }
 }
 

--- a/src/blocks/popup/__title/popup__title.css
+++ b/src/blocks/popup/__title/popup__title.css
@@ -8,6 +8,15 @@
   letter-spacing: -.5px;
 }
 
+@media screen and (min-width: 425px) {
+  .popup__title {
+    font-size: 30px;
+    line-height: 37px;
+    letter-spacing: -1px;
+    padding-bottom: 30px;
+  }
+}
+
 @media screen and (min-width: 768px) {
   .popup__title {
     padding-bottom: 30px;

--- a/src/index.html
+++ b/src/index.html
@@ -123,15 +123,11 @@
               Python Start
             </h4>
             <ul class="courses__spec-list list">
-              <li class="courses__spec courses__spec_type_human">
-                <p class="courses__spec-text paragraph">
-                  группы 8+&nbsp;лет
-                </p>
+              <li class="courses__spec courses__spec_type_human courses__spec-text">
+                группы 8+&nbsp;лет
               </li>
-              <li class="courses__spec courses__spec_type_time">
-                <p class="courses__spec-text paragraph">
-                  блоки по&nbsp;3&nbsp;месяца
-                </p>
+              <li class="courses__spec courses__spec_type_time courses__spec-text">
+                блоки по&nbsp;3&nbsp;месяца
               </li>
             </ul>
             <ul class="courses__tags list">
@@ -143,11 +139,9 @@
             <p class="courses__card-text paragraph">
               Студенты к&nbsp;концу курса будут сами создавать приложения. А&nbsp;ещё они научатся:
             </p>
-            <ul class="courses__skills">
-              <li class="courses__card-text">
-                <p class="paragraph list__item list__item_type_checked">
+            <ul class="courses__skills list">
+              <li class="paragraph courses__skills-item list__item list__item_type_checked">
                   Разбираться в&nbsp;основах алгоритмики и&nbsp;объектно-ориентированного программирования
-                </p>
               </li>
             </ul>
             <div class="courses__buttons">
@@ -169,15 +163,11 @@
               Создание web-сайтов
             </h4>
             <ul class="courses__spec-list list">
-              <li class="courses__spec courses__spec_type_human">
-                <p class="courses__spec-text paragraph">
-                  группы 11-13 лет
-                </p>
+              <li class="courses__spec courses__spec_type_human courses__spec-text">
+                группы 11-13 лет
               </li>
-              <li class="courses__spec courses__spec_type_time">
-                <p class="courses__spec-text paragraph">
-                  1&nbsp;год, блоками по&nbsp;3&nbsp;месяца
-                </p>
+              <li class="courses__spec courses__spec_type_time courses__spec-text">
+                1&nbsp;год, блоками по&nbsp;3&nbsp;месяца
               </li>
             </ul>
             <ul class="courses__tags list">
@@ -211,15 +201,11 @@
               Корейский язык
             </h3>
             <ul class="courses__spec-list list">
-              <li class="courses__spec courses__spec_type_human">
-                <p class="courses__spec-text paragraph">
-                  группы 8+&nbsp;лет
-                </p>
+              <li class="courses__spec courses__spec_type_human courses__spec-text">
+                группы 8+&nbsp;лет
               </li>
-              <li class="courses__spec courses__spec_type_time">
-                <p class="courses__spec-text paragraph">
-                  блоки по&nbsp;3&nbsp;месяца
-                </p>
+              <li class="courses__spec courses__spec_type_time courses__spec-text">
+                блоки по&nbsp;3&nbsp;месяца
               </li>
             </ul>
             <ul class="courses__tags list">
@@ -246,15 +232,11 @@
               Английский язык
             </h3>
             <ul class="courses__spec-list list">
-              <li class="courses__spec courses__spec_type_human">
-                <p class="courses__spec-text paragraph">
-                  группы 8+&nbsp;лет
-                </p>
+              <li class="courses__spec courses__spec_type_human courses__spec-text">
+                группы 6+&nbsp;лет, 10+&nbsp;лет, взрослые
               </li>
-              <li class="courses__spec courses__spec_type_time">
-                <p class="courses__spec-text paragraph">
-                  блоки по&nbsp;3&nbsp;месяца
-                </p>
+              <li class="courses__spec courses__spec_type_time courses__spec-text">
+                блоки по&nbsp;3&nbsp;месяца
               </li>
             </ul>
             <ul class="courses__tags list">
@@ -282,15 +264,11 @@
               3D технологии
             </h3>
             <ul class="courses__spec-list list">
-              <li class="courses__spec courses__spec_type_human">
-                <p class="courses__spec-text paragraph">
-                  группы 8+&nbsp;лет
-                </p>
+              <li class="courses__spec courses__spec_type_human courses__spec-text">
+                группы 8+&nbsp;лет
               </li>
-              <li class="courses__spec courses__spec_type_time">
-                <p class="courses__spec-text paragraph">
-                  блоки по&nbsp;3&nbsp;месяца
-                </p>
+              <li class="courses__spec courses__spec_type_time courses__spec-text">
+                блоки по&nbsp;3&nbsp;месяца
               </li>
             </ul>
             <ul class="courses__tags list">
@@ -328,31 +306,20 @@
             Что входит в&nbsp;стоимость?
           </h4>
           <ul class="list courses__list">
-            <li class="list__item list__item_type_checked">
-              <p class="paragraph">
-                2&nbsp;занятия в&nbsp;неделю по&nbsp;2&nbsp;часа
-              </p>
+            <li class="list__item list__item_type_checked paragraph">
+              2&nbsp;занятия в&nbsp;неделю по&nbsp;2&nbsp;часа
             </li>
-            <li class="list__item list__item_type_checked">
-              <p class="paragraph">
-                Небольшие группы до&nbsp;10&nbsp;чел.
-              </p>
+            <li class="list__item list__item_type_checked paragraph">
+              Небольшие группы до&nbsp;10&nbsp;чел.
             </li>
-            <li class="list__item list__item_type_checked">
-              <p class="paragraph">
-                1&nbsp;личная консультация в&nbsp;месяц для студентов курсов
-              </p>
+            <li class="list__item list__item_type_checked paragraph">
+              1&nbsp;личная консультация в&nbsp;месяц для студентов курсов
             </li>
-            <li class="list__item list__item_type_checked">
-              <p class="paragraph">
-                Снэки, вода, чай на&nbsp;нашей кухне
-              </p>
+            <li class="list__item list__item_type_checked paragraph">
+              Снэки, вода, чай на&nbsp;нашей кухне
             </li>
-            <li class="list__item list__item_type_checked">
-              <p class="paragraph">
-                1&nbsp;консультация для родителей о&nbsp;курсе
-                и&nbsp;достижениях студентов
-              </p>
+            <li class="list__item list__item_type_checked paragraph">
+              1&nbsp;консультация для родителей о&nbsp;курсе и&nbsp;достижениях студентов
             </li>
           </ul>
         </article>
@@ -361,21 +328,14 @@
             Что не&nbsp;входит в&nbsp;стоимость?
           </h4>
           <ul class="list courses__list">
-            <li class="list__item list__item_type_crossed">
-              <p class="paragraph">
-                Трансфер из&nbsp;вашего аула к&nbsp;центру
-              </p>
+            <li class="list__item list__item_type_crossed paragraph">
+              Трансфер из&nbsp;вашего аула к&nbsp;центру
             </li>
-            <li class="list__item list__item_type_crossed">
-              <p class="paragraph">
-                Индивидуальные занятия
-              </p>
+            <li class="list__item list__item_type_crossed paragraph">
+              Индивидуальные занятия
             </li>
-            <li class="list__item list__item_type_crossed">
-              <p class="paragraph">
-                Ежегодный членский взнос в&nbsp;размере 1&nbsp;500&nbsp;₽
-                (оплачивается раз в&nbsp;год в&nbsp;начале курса)
-              </p>
+            <li class="list__item list__item_type_crossed paragraph">
+              Ежегодный членский взнос в&nbsp;размере 1&nbsp;500&nbsp;₽ (оплачивается раз в&nbsp;год в&nbsp;начале курса)
             </li>
           </ul>
         </article>
@@ -606,18 +566,14 @@
             data-link="https://docs.google.com/forms/d/e/1FAIpQLScRkeum4swQ7Kyv1-04uBeVWIdb8AwhyJE2np9_wFp5ucp3qw/viewform">
     <div class="popup__content">
       <h2 class="popup__title">
-        3D технологии
+        Python Start
       </h2>
       <ul class="courses__spec-list popup__spec-list list">
-        <li class="courses__spec courses__spec_type_human popup__spec">
-          <p class="courses__spec-text">
-            группы 8+&nbsp;лет
-          </p>
+        <li class="courses__spec courses__spec_type_human popup__spec courses__spec-text">
+          группы 8+&nbsp;лет
         </li>
-        <li class="courses__spec courses__spec_type_time popup__spec">
-          <p class="courses__spec-text">
-            блоки по&nbsp;3&nbsp;месяца
-          </p>
+        <li class="courses__spec courses__spec_type_time popup__spec courses__spec-text">
+          блоки по&nbsp;3&nbsp;месяца
         </li>
       </ul>
       <ul class="courses__tags list">
@@ -626,39 +582,39 @@
         <li class="tag">создание своего портфолио</li>
         <li class="tag">создание web-сайтов</li>
       </ul>
-      <p class="courses__card-text">
+      <p class="courses__card-text paragraph">
         Студенты к концу курса будут сами создавать приложения. А ещё они научатся:
       </p>
       <ul class="list courses__skills-list">
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Разбираться в основах алгоритмики и объектно-ориентированного программирования
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Разрабатывать графические интерактивные игры для ПК, используя библиотеку PyGame
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Работать с графикой и использовать библиотеку Turtle
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Решать реальные задачи, используя Python, и применять итеративный подход
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Применять принципы проектной работы при создании проектов
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Писать и читать код на языке Python и работать со структурами данных
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Разрабатывать сложные игры и приложения для ПК, используя библиотеки PyGame
           и PyQT
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Проектировать интерфейсы
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Автоматизировать работу с графическими файлами
         </li>
-        <li class="courses__skills-item">
+        <li class="courses__skills-item courses__skills-item_unclamped paragraph list__item list__item_type_checked">
           Работать в команде и создавать проекты от идеи до их публичной презентации
         </li>
       </ul>

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -76,6 +76,7 @@
 @import '../blocks/courses/__skills/courses__skills.css';
 @import '../blocks/courses/__skills-list/courses__skills-list.css';
 @import '../blocks/courses/__skills-item/courses__skills-item.css';
+@import '../blocks/courses/__skills-item/_unclamped/courses__skills-item_unclamped.css';
 @import '../blocks/courses/__buttons/courses__buttons.css';
 @import '../blocks/courses/__all-button/courses__all-button.css';
 @import '../blocks/courses/__others/courses__others.css';
@@ -93,7 +94,6 @@
 @import '../blocks/popup/__container/popup__container.css';
 @import '../blocks/popup/__container/_size/popup__container_size_small.css';
 @import '../blocks/popup/__container/_size/popup__container_size_medium.css';
-@import '../blocks/popup/__container/popup__container.css';
 @import '../blocks/popup/__close/popup__close.css';
 @import '../blocks/popup/__close/_type/popup__close_type_button.css';
 @import '../blocks/popup/__close/_type/popup__close_type_icon.css';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ scroller.init();
 
 
 window.addEventListener('scroll', () => {
-  if (window.matchMedia('(min-width: 769px)').matches) {
+  if (window.matchMedia('(min-width: 1111px)').matches) {
     if (window.scrollY > 0) {
       logo.classList.add('logo__img_scrolled');
       page.classList.add('page_scrolled');


### PR DESCRIPTION
- пофиксил скролл (появлялся на винде, где скроллбар занимает ширину окна - по факту пейдж был примерно 300, а окно со скроллом вместе - 320-340)
- убрал теги `<p>`, вложенные в теги `<li>`
- в процессе поехал текст в пачке мест, фиксил его)0
- в том числе в попапах, так как они используют те же стили
- поправил `matchMedia` в `index.js` на 1111, чтобы лого при скролле менялось только после нового брейккпоинта хедера
-  убрал составные селекторы